### PR TITLE
make chain an instance of torecord for csv encoding

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+- 1.1.0 (2020-06-XX)
+		* Make `Chain` an instance of `ToRecord` for CSV encoding.
+
 - 1.0.3 (2016-12-04)
 		* Add missing dependency bounds.
 

--- a/Data/Sampling/Types.hs
+++ b/Data/Sampling/Types.hs
@@ -36,6 +36,9 @@ module Data.Sampling.Types (
   ) where
 
 import Control.Monad.Trans.State.Strict (StateT)
+import Data.Csv
+import Data.Maybe (fromMaybe)
+import qualified Data.Vector as V
 import System.Random.MWC.Probability (Prob)
 
 -- | A generic transition operator.
@@ -54,6 +57,14 @@ data Chain a b = Chain {
 
 instance Show a => Show (Chain a b) where
   show Chain {..} = filter (`notElem` "fromList []") (show chainPosition)
+
+instance (ToRecord a, ToRecord b) => ToRecord (Chain a b) where
+  toRecord Chain {..} =
+    V.concat
+      [ (record [toField chainScore])
+      , (toRecord chainPosition)
+      , fromMaybe V.empty (toRecord <$> chainTunables)
+      ]
 
 -- | A @Target@ consists of a function from parameter space to the reals, as
 --   well as possibly a gradient.

--- a/mcmc-types.cabal
+++ b/mcmc-types.cabal
@@ -1,5 +1,5 @@
 name:                mcmc-types
-version:             1.0.3
+version:             1.1.0
 synopsis:            Common types for sampling.
 homepage:            http://github.com/jtobin/mcmc-types
 license:             MIT
@@ -35,4 +35,6 @@ library
     , containers      >= 0.5 && < 6
     , mwc-probability >= 1.0.1
     , transformers    >= 0.5 && < 1.0
+    , cassava         >= 0.5.1.0
+    , vector          >= 0.12
 


### PR DESCRIPTION
Make the `Chain` type an instance of `ToRecord` from `cassava` to simplify the process of serialising to a CSV.  